### PR TITLE
🔒 Restrict overly permissive CORS policy in API server

### DIFF
--- a/config/settings.example.yaml
+++ b/config/settings.example.yaml
@@ -70,6 +70,10 @@ logging:
   json: true
   file: "logs/maxos.log"
 
+api:
+  allowed_origins:
+    - "http://localhost:3000"
+
 telemetry:
   enabled: false
   endpoint: "https://telemetry.tezzaworks.ai"

--- a/max_os/interfaces/api/server.py
+++ b/max_os/interfaces/api/server.py
@@ -16,9 +16,15 @@ logger = structlog.get_logger("max_os.api")
 
 app = FastAPI(title="MaxOS Neural Link")
 
+# Load global settings manager
+settings_manager = load_settings()
+
+# Get allowed origins from settings or default to local development address
+allowed_origins = settings_manager.api.get("allowed_origins", ["http://localhost:3000"])
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -50,9 +56,6 @@ runner_ref = None
 def set_runner(runner):
     global runner_ref
     runner_ref = runner
-
-# Load global settings manager
-settings_manager = load_settings()
 
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):

--- a/max_os/interfaces/api/server.py
+++ b/max_os/interfaces/api/server.py
@@ -5,11 +5,13 @@ Serves the Frontend and providing a WebSocket stream for real-time state.
 """
 
 import asyncio
-from typing import List, Dict, Any
+from typing import Any
+
 import structlog
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+
 from max_os.utils.config import load_settings
 
 logger = structlog.get_logger("max_os.api")
@@ -33,7 +35,7 @@ app.add_middleware(
 # --- WebSocket Manager ---
 class ConnectionManager:
     def __init__(self):
-        self.active_connections: List[WebSocket] = []
+        self.active_connections: list[WebSocket] = []
 
     async def connect(self, websocket: WebSocket):
         await websocket.accept()

--- a/max_os/utils/config.py
+++ b/max_os/utils/config.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import os
-import yaml
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
-from dotenv import load_dotenv
+
 import structlog
+import yaml
+from dotenv import load_dotenv
 
 load_dotenv()
 logger = structlog.get_logger("max_os.config")
@@ -53,7 +54,8 @@ class Settings:
         """Persists current state to YAML."""
         data = asdict(self)
         # Remove internal fields
-        if "_file_path" in data: del data["_file_path"]
+        if "_file_path" in data:
+            del data["_file_path"]
         
         try:
             with open(self._file_path, "w", encoding="utf-8") as f:

--- a/max_os/utils/config.py
+++ b/max_os/utils/config.py
@@ -25,6 +25,7 @@ class Settings:
     logging: dict[str, Any] = field(default_factory=dict)
     telemetry: dict[str, Any] = field(default_factory=dict)
     multi_agent: dict[str, Any] = field(default_factory=dict)
+    api: dict[str, Any] = field(default_factory=dict)
     
     # Phase 6: Accessibility & Control
     accessibility: dict[str, Any] = field(default_factory=lambda: {


### PR DESCRIPTION
🎯 **What:** Fixed the overly permissive CORS policy in the FastAPI server by replacing `allow_origins=["*"]` with a configurable list of allowed origins.

⚠️ **Risk:** A wildcard origin (`"*"`) allows any website to make requests to the API. When combined with `allow_credentials=True`, it can lead to Cross-Site Request Forgery (CSRF) or unauthorized data access if a user is authenticated in the same browser. Most modern browsers and frameworks also discourage or block this combination for security reasons.

🛡️ **Solution:** Introduced an `api.allowed_origins` configuration setting that defaults to `["http://localhost:3000"]` (a common local development address). The API server now loads this configuration and applies it to the `CORSMiddleware`. This restricts API access to trusted origins while maintaining functionality for the frontend.

---
*PR created automatically by Jules for task [1212374007372290241](https://jules.google.com/task/1212374007372290241) started by @MaxTezza*